### PR TITLE
Wip on spi bradfa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.lst
+*.obj
+*.pp
+*.s
+pru0_spi

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CFLAGS= -v3 -s -al -O3 --c99 --gcc --printf_support=minimal --symdebug:none $(IN
 LDFLAGS=-cr --diag_warning=225 -lam335x_pru.cmd -x -i$(CGTDIR)/lib
 
 pru0_spi: pru0_spi.obj
-	$(CC) $(CFLAGS) $^ -q -z $(LDFLAGS) -o $@
+	$(LD) $(LDFLAGS) $^ -o $@
 
 %.obj: %.c
 	$(CC) $(CFLAGS) -c $< -ea=.s

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,16 @@
 # * Makefile for PRU firmware
 # * Builds only with CLPRU 2.0.0B* and above
-# BBB hostname
-BBHOST = root@192.168.7.2
 
 # Tools to be used
-CC=clpru
-LD=lnkpru
+CC = clpru
+LD = lnkpru
 
-# Default installation location for TI code generation tools (TI-CGT PRU)
+# Default installation location for TI code generation tools (TI-CGT PRU) is
+# in your home directory (if you're sane).
 # Change if you have installed at some other location
-CGTDIR = /home/vc/Desktop/beagle-gsoc/compile/ti-cgt-pru_2.1.2
+CGTDIR ?= $(HOME)/ti-cgt-pru_2.1.2
 
-# PRU software support package by TI
-SWDIR ?= /home/vc/Desktop/beagle-gsoc/compile/pru-software-support-package
-
-INCLUDEDIR = -I$(SWDIR)/include -I$(SWDIR)/include/am335x -I$(CGTDIR)/include -I$(CGTDIR)/lib -I./include
+INCLUDEDIR = -I$(CGTDIR)/include -I$(CGTDIR)/lib -I./include
 
 # Compiler Options
 # -v3				PRU version 3
@@ -30,29 +26,16 @@ CFLAGS= -v3 -s -al -O3 --c99 --gcc --printf_support=minimal --symdebug:none $(IN
 # Linker Options
 # -cr 				Link using RAM auto init model (loader assisted)
 # -x				Reread libs until no unresolved symbols found
-LDFLAGS=-cr --diag_warning=225 -lam335x_pru.cmd -x
+LDFLAGS=-cr --diag_warning=225 -lam335x_pru.cmd -x -i$(CGTDIR)/lib
 
-.PHONY: all clean
-
-all: pru0_spi
+pru0_spi: pru0_spi.obj
+	$(CC) $(CFLAGS) $^ -q -z $(LDFLAGS) -o $@
 
 %.obj: %.c
-	@echo "  CC	$@"
-	@$(CC) $(CFLAGS) -c $< -ea=.s
+	$(CC) $(CFLAGS) -c $< -ea=.s
 
-pru0_spi: pru0_spi
-	@echo "  LD	$@"
-	@$(CC) $(CFLAGS) $^ -q -z $(LDFLAGS) -o $@
-	
-#install-frombb: rproc-pru0-fw rproc-pru1-fw
-#	cp -t /lib/firmware rproc-pru0-fw
-#	cp -t /lib/firmware rproc-pru1-fw
-
-#install-tobb: rproc-pru0-fw rproc-pru1-fw
-#	scp -q rproc-pru0-fw $(BBHOST):/lib/firmware
-#	scp -q rproc-pru1-fw $(BBHOST):/lib/firmware
-
+.PHONY: clean
 clean:
-	rm -f *.obj *.lst *.s rproc-pru0-fw rproc-pru1-fw *.pp
+	rm -f *.lst *.obj *.pp *.s pru0_spi
 
 -include $(patsubst %.obj,%.pp,$(OBJS))

--- a/am335x_pru.cmd
+++ b/am335x_pru.cmd
@@ -1,0 +1,86 @@
+/****************************************************************************/
+/*  AM335x_PRU.cmd                                                          */
+/*  Copyright (c) 2015  Texas Instruments Incorporated                      */
+/*                                                                          */
+/*    Description: This file is a linker command file that can be used for  */
+/*                 linking PRU programs built with the C compiler and       */
+/*                 the resulting .out file on an AM335x device.             */
+/****************************************************************************/
+
+-cr								/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	PRU_IMEM		: org = 0x00000000 len = 0x00002000  /* 8kB PRU0 Instruction RAM */
+
+      PAGE 1:
+
+	/* RAM */
+
+	PRU_DMEM_0_1	: org = 0x00000000 len = 0x00002000 CREGISTER=24 /* 8kB PRU Data RAM 0_1 */
+	PRU_DMEM_1_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25 /* 8kB PRU Data RAM 1_0 */
+	
+	  PAGE 2:
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00003000 CREGISTER=28 /* 12kB Shared RAM */
+
+	DDR			    : org = 0x80000000 len = 0x00000100	CREGISTER=31
+	L3OCMC			: org = 0x40000000 len = 0x00010000	CREGISTER=30
+
+
+	/* Peripherals */
+
+	PRU_CFG			: org = 0x00026000 len = 0x00000044	CREGISTER=4
+	PRU_ECAP		: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_IEP			: org = 0x0002E000 len = 0x0000031C	CREGISTER=26
+	PRU_INTC		: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_UART		: org = 0x00028000 len = 0x00000038	CREGISTER=7
+
+	DCAN0			: org = 0x481CC000 len = 0x000001E8	CREGISTER=14
+	DCAN1			: org = 0x481D0000 len = 0x000001E8	CREGISTER=15
+	DMTIMER2		: org = 0x48040000 len = 0x0000005C	CREGISTER=1
+	PWMSS0			: org = 0x48300000 len = 0x000002C4	CREGISTER=18
+	PWMSS1			: org = 0x48302000 len = 0x000002C4	CREGISTER=19
+	PWMSS2			: org = 0x48304000 len = 0x000002C4	CREGISTER=20
+	GEMAC			: org = 0x4A100000 len = 0x0000128C	CREGISTER=9
+	I2C1			: org = 0x4802A000 len = 0x000000D8	CREGISTER=2
+	I2C2			: org = 0x4819C000 len = 0x000000D8	CREGISTER=17
+	MBX0			: org = 0x480C8000 len = 0x00000140	CREGISTER=22
+	MCASP0_DMA		: org = 0x46000000 len = 0x00000100	CREGISTER=8
+	MCSPI0			: org = 0x48030000 len = 0x000001A4	CREGISTER=6
+	MCSPI1			: org = 0x481A0000 len = 0x000001A4	CREGISTER=16
+	MMCHS0			: org = 0x48060000 len = 0x00000300	CREGISTER=5
+	SPINLOCK		: org = 0x480CA000 len = 0x00000880	CREGISTER=23
+	TPCC			: org = 0x49000000 len = 0x00001098	CREGISTER=29
+	UART1			: org = 0x48022000 len = 0x00000088	CREGISTER=11
+	UART2			: org = 0x48024000 len = 0x00000088	CREGISTER=12
+
+	RSVD10			: org = 0x48318000 len = 0x00000100	CREGISTER=10
+	RSVD13			: org = 0x48310000 len = 0x00000100	CREGISTER=13
+	RSVD21			: org = 0x00032400 len = 0x00000100	CREGISTER=21
+	RSVD27			: org = 0x00032000 len = 0x00000100	CREGISTER=27
+
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU_DMEM_0_1, PAGE 1
+	.bss		>  PRU_DMEM_0_1, PAGE 1
+	.cio		>  PRU_DMEM_0_1, PAGE 1
+	.data		>  PRU_DMEM_0_1, PAGE 1
+	.switch		>  PRU_DMEM_0_1, PAGE 1
+	.sysmem		>  PRU_DMEM_0_1, PAGE 1
+	.cinit		>  PRU_DMEM_0_1, PAGE 1
+	.rodata		>  PRU_DMEM_0_1, PAGE 1
+	.rofardata	>  PRU_DMEM_0_1, PAGE 1
+	.farbss		>  PRU_DMEM_0_1, PAGE 1
+	.fardata	>  PRU_DMEM_0_1, PAGE 1
+
+	.resource_table > PRU_DMEM_0_1, PAGE 1
+}

--- a/include/pru_cfg.h
+++ b/include/pru_cfg.h
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2015 Texas Instruments Incorporated - http://www.ti.com/ 
+ *  
+ *  
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions 
+ * are met:
+ * 
+ * 	* Redistributions of source code must retain the above copyright 
+ * 	  notice, this list of conditions and the following disclaimer.
+ * 
+ * 	* Redistributions in binary form must reproduce the above copyright
+ * 	  notice, this list of conditions and the following disclaimer in the 
+ * 	  documentation and/or other materials provided with the   
+ * 	  distribution.
+ * 
+ * 	* Neither the name of Texas Instruments Incorporated nor the names of
+ * 	  its contributors may be used to endorse or promote products derived
+ * 	  from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PRU_CFG_H_
+#define _PRU_CFG_H_
+
+/* PRU_CFG register set */
+typedef struct{
+
+	/* PRU_CFG_REVID register bit field */
+	union {
+		volatile uint32_t REVID;
+
+		volatile struct {
+			unsigned REVID : 32;
+		} REVID_bit;
+	} ;	// 0x0
+
+
+	/* PRU_CFG_SYSCFG register bit field */
+	union {
+		volatile uint32_t SYSCFG;
+
+		volatile struct{
+			unsigned IDLE_MODE : 2;
+			unsigned STANDBY_MODE : 2;
+			unsigned STANDBY_INIT : 1;
+			unsigned SUB_MWAIT : 1;
+			unsigned rsvd6 : 26;
+		} SYSCFG_bit;
+	} ;	// 0x4
+
+
+	/* PRU_CFG_GPCFG0 register bit field */
+	union {
+		volatile uint32_t GPCFG0;
+
+		volatile struct{
+			unsigned PRU0_GPI_MODE : 2;	// 1:0
+			unsigned PRU0_GPI_CLK_MODE : 1;	// 2
+			unsigned PRU0_GPI_DIV0 : 5;	// 7:3
+			unsigned PRU0_GPI_DIV1 : 5;	// 12:8
+			unsigned PRU0_GPI_SB : 1;	// 13
+			unsigned PRU0_GPO_MODE : 1;	// 14
+			unsigned PRU0_GPO_DIV0 : 5;	// 19:15
+			unsigned PRU0_GPO_DIV1 : 5;	// 24:20
+			unsigned PRU0_GPO_SH_SEL : 1;	// 25
+			unsigned rsvd26 : 6;		// 31:26
+		} GPCFG0_bit;
+	} ;	// 0x8
+
+
+	/* PRU_CFG_GPCFG1 register bit field */
+	union {
+		volatile uint32_t GPCFG1;
+
+		volatile struct{
+			unsigned PRU1_GPI_MODE : 2;	// 1:0
+			unsigned PRU1_GPI_CLK_MODE : 1;	// 2
+			unsigned PRU1_GPI_DIV0 : 5;	// 7:3
+			unsigned PRU1_GPI_DIV1 : 5;	// 12:8
+			unsigned PRU1_GPI_SB : 1;	// 13
+			unsigned PRU1_GPO_MODE : 1;	// 14
+			unsigned PRU1_GPO_DIV0 : 5;	// 19:15
+			unsigned PRU1_GPO_DIV1 : 5;	// 24:20
+			unsigned PRU1_GPO_SH_SEL : 1;	// 25
+			unsigned rsvd26 : 6;		// 31:26
+		} GPCFG1_bit;
+	} ;	// 0xC
+
+
+	/* PRU_CFG_CGR register bit field */
+	union {
+		volatile uint32_t CGR;
+
+		volatile struct{
+			unsigned PRU0_CLK_STOP_REQ : 1;	// 0
+			unsigned PRU0_CLK_STOP_ACK : 1;	// 1
+			unsigned PRU0_CLK_EN : 1;	// 2
+			unsigned PRU1_CLK_STOP_REQ : 1;	// 3
+			unsigned PRU1_CLK_STOP_ACK : 1;	// 4
+			unsigned PRU1_CLK_EN : 1;	// 5
+			unsigned INTC_CLK_STOP_REQ : 1;	// 6
+			unsigned INTC_CLK_STOP_ACK : 1;	// 7
+			unsigned INTC_CLK_EN : 1;	// 8
+			unsigned UART_CLK_STOP_REQ : 1;	// 9
+			unsigned UART_CLK_STOP_ACK : 1;	// 10
+			unsigned UART_CLK_EN : 1;	// 11
+			unsigned ECAP_CLK_STOP_REQ : 1;	// 12
+			unsigned ECAP_CLK_STOP_ACK : 1;	// 13
+			unsigned ECAP_CLK_EN : 1;	// 14
+			unsigned IEP_CLK_STOP_REQ : 1;	// 15
+			unsigned IEP_CLK_STOP_ACK : 1;	// 16
+			unsigned IEP_CLK_EN : 1;	// 17
+			unsigned rsvd18 : 14;		// 31:18
+		} CGR_bit;
+	} ;	// 0x10
+
+
+	/* PRU_CFG_ISRP register bit field */
+	union {
+		volatile uint32_t ISRP;
+
+		volatile  struct{
+			unsigned PRU0_IMEM_PE_RAW : 4;	// 3:0
+			unsigned PRU0_DMEM_PE_RAW : 4;	// 7:4
+			unsigned PRU1_IMEM_PE_RAW : 4;	// 11:8
+			unsigned PRU1_DMEM_PE_RAW : 4;	// 15:12
+			unsigned RAM_PE_RAW : 4;	// 19:16
+			unsigned rsvd20 : 12;		// 31:20
+		} ISRP_bit;
+	} ;	// 0x14
+
+
+	/* PRU_CFG_ISP register bit field */
+	union {
+		volatile uint32_t ISP;
+
+		volatile  struct{
+			unsigned PRU0_IMEM_PE : 4;	// 3:0
+			unsigned PRU0_DMEM_PE : 4;	// 7:4
+			unsigned PRU1_IMEM_PE : 4;	// 11:8
+			unsigned PRU1_DMEM_PE : 4;	// 15:12
+			unsigned RAM_PE : 4;		// 19:16
+			unsigned rsvd20 : 12;		// 31:20
+		} ISP_bit;
+	} ;	// 0x18
+
+	/* PRU_CFG_IESP register bit field */
+	union {
+		volatile uint32_t IESP;
+
+		volatile struct{
+			unsigned PRU0_IMEM_PE_SET : 4;	// 3:0
+			unsigned PRU0_DMEM_PE_SET : 4;	// 7:4
+			unsigned PRU1_IMEM_PE_SET : 4;	// 11:8
+			unsigned PRU1_DMEM_PE_SET : 4;	// 15:12
+			unsigned RAM_PE_SET : 4;	// 19:16
+			unsigned rsvd20 : 12;		// 31:20
+		} IESP_bit;
+	} ;	// 0x1C
+
+
+	/* PRU_CFG_IECP register bit field */
+	union {
+		volatile uint32_t IECP;
+
+		volatile struct{
+			unsigned PRU0_IMEM_PE_CLR : 4;	// 3:0
+			unsigned PRU0_DMEM_PE_CLR : 4;	// 7:4
+			unsigned PRU1_IMEM_PE_CLR : 4;	// 11:8
+			unsigned PRU1_DMEM_PE_CLR : 4;	// 15:12
+			unsigned rsvd16 : 16;		// 31:16
+		} IECP_bit;
+	} ;	// 0x20
+
+
+	uint32_t rsvd24;	// 0x24
+
+
+	/* PRU_CFG_PMAO register bit field */
+	union {
+		volatile uint32_t PMAO;
+
+		volatile struct{
+			unsigned PMAO_PRU0 : 1;		// 0
+			unsigned PMAO_PRU1 : 1;		// 1
+			unsigned rsvd2 : 30;		// 31:2
+		} PMAO_bit;
+	} ;	// 0x28
+
+
+        uint32_t rsvd2c[1];     // 0x2C
+
+
+	/* PRU_CFG_IEPCLK register bit field */
+	union {
+		volatile uint32_t IEPCLK;
+
+		volatile struct{
+			unsigned OCP_EN : 1;		// 0
+			unsigned rsvd1 : 31;		// 31:1
+		} IEPCLK_bit;
+	} ;	// 0x30
+
+
+	/* PRU_CFG_SPP register bit field */
+	union {
+		volatile uint32_t SPP;
+
+		volatile struct{
+			unsigned PRU1_PAD_HP_EN : 1;	// 0
+			unsigned XFR_SHIFT_EN : 1;	// 1
+			unsigned rsvd2 : 30;		// 31:2
+		} SPP_bit;
+	} ;	// 0x34
+
+
+	uint32_t rsvd38[2];	// 0x38 - 0x3C
+
+
+	union {
+		volatile uint32_t PIN_MX;
+
+		volatile struct {
+			unsigned PIN_MUX_SEL : 8;	// 7:0
+			unsigned rsvd2 : 24;		// 31:8
+		} PIN_MX_bit;
+	} ;	//0x40
+} pruCfg;
+
+volatile __far pruCfg CT_CFG __attribute__((cregister("PRU_CFG", near), peripheral));
+
+#endif /* _PRU_CFG_H_ */


### PR DESCRIPTION
A few small changes to get compiling close to working.

You can run the Makefile and pass it where your CGTDIR is like:

```
make CGTDIR=/home/vc/Desktop/beagle-gsoc/compile/ti-cgt-pru_2.1.2
```

Compiling still fails, as the output binary is too big for the specified size, but at least now the compiler is doing the right thing.

You need to ensure that the `clpru` compiler application and 'lnkpru' linker application is in your path.  You can do this like:

```
export PATH=$PATH:/home/<yourusername>/ti-cgt-pru_2.1.2/bin
```
