### PR TITLE
Remove need for TI Linux SDK to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,6 @@
 #(Linux) export PRU_CGT=/home/jason/ti/ccs_v6_1_0/ccsv6/tools/compiler/ti-cgt-pru_2.1.0
 #(Windows) set PRU_CGT=C:/TI/ccs_v6_0_1/ccsv6/tools/compiler/ti-cgt-pru_2.1.0
 
-#Similarly PRU_SW_PKG should point to the location where you have installed PRU Software
-#Support Package.Example:
-#(Linux)export PRU_SW_PKG=/home/vc/Desktop/beagle-gsoc/compile/pru-software-support-package
 ifndef PRU_CGT
 define ERROR_BODY
 
@@ -52,25 +49,11 @@ endef
 $(error $(ERROR_BODY))
 endif
 
-ifndef PRU_SW_PKG
-define ERROR_BODY
-
-***************************************************************************************************
-PRU_SW_PKG environment variable is not set. Examples given:
-(Linux)export PRU_SW_PKG=/home/vc/Desktop/beagle-gsoc/compile/pru-software-support-package
-Please set the variable to the location of the pru-software-support-package to compile the Firmware.
-****************************************************************************************************
-
-endef
-$(error $(ERROR_BODY))
-endif
-
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(MKFILE_PATH))))
 PROJ_NAME=$(CURRENT_DIR)
 LINKER_COMMAND_FILE=./AM335x_PRU.cmd
-LIBS=--library=$(PRU_SW_PKG)/lib/rpmsg_lib.lib 
-INCLUDE=--include_path=$(PRU_SW_PKG)/include --include_path=$(PRU_SW_PKG)/include/am335x 
+INCLUDE=--include_path=./include/
 STACK_SIZE=0x100
 HEAP_SIZE=0x100
 GEN_DIR=gen
@@ -107,7 +90,7 @@ $(TARGET): $(OBJECTS) $(LINKER_COMMAND_FILE)
 	@echo ''
 	@echo 'Building target: $@'
 	@echo 'Invoking: PRU Linker'
-	$(PRU_CGT)/bin/clpru $(CFLAGS) -z -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $(TARGET) $(OBJECTS) -m$(MAP) $(LINKER_COMMAND_FILE) --library=libc.a $(LIBS)
+	$(PRU_CGT)/bin/clpru $(CFLAGS) -z -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $(TARGET) $(OBJECTS) -m$(MAP) $(LINKER_COMMAND_FILE) --library=libc.a
 	@echo 'Finished building target: $@'
 	@echo ''
 	@echo 'Output files can be found in the "$(GEN_DIR)" directory'

--- a/Readme.md
+++ b/Readme.md
@@ -8,15 +8,12 @@ To test the firmware code ,perform the following steps:
 1) Before compiling the code,the PRU_CGT variable must point to the TI PRU compiler directory.As an example:
     export PRU_CGT=/home/vc/Desktop/beagle-gsoc/compile/ti-cgt-pru_2.1.0
 
-2)Then set the PRU_SW_PKG variable to point to the current location of the pru-software support package folder.As an example:
-    export PRU_SW_PKG=/home/vc/Desktop/beagle-gsoc/compile/pru-software-support-package	
+2)Then simply run make to compile the code.
 
-3)Then simply run make to compile the code.
+3)An obj file should appear in the gen folder .
 
-4)An obj file should appear in the gen folder .
+4)Then scp the file to /lib/firmware/am335x-pru0-fw on the BeagleBone
 
-5)Then scp the file to /lib/firmware/am335x-pru0-fw on the BeagleBone
+5)Use config-pin to configure P8_11 and P8_12 as output pins.Use config-pin -h for help with syntax.
 
-6)Use config-pin to configure P8_11 and P8_12 as output pins.Use config-pin -h for help with syntax.
-
-7)Then rmmod pru_rproc and modprobe pru_rproc to load the firmware.Observe with a logic analyzer.
+6)Then rmmod pru_rproc and modprobe pru_rproc to load the firmware.Observe with a logic analyzer.

--- a/include/pru_types.h
+++ b/include/pru_types.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 Texas Instruments Incorporated - http://www.ti.com/ 
+ *  
+ *  
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions 
+ * are met:
+ * 
+ * 	* Redistributions of source code must retain the above copyright 
+ * 	  notice, this list of conditions and the following disclaimer.
+ * 
+ * 	* Redistributions in binary form must reproduce the above copyright
+ * 	  notice, this list of conditions and the following disclaimer in the 
+ * 	  documentation and/or other materials provided with the   
+ * 	  distribution.
+ * 
+ * 	* Neither the name of Texas Instruments Incorporated nor the names of
+ * 	  its contributors may be used to endorse or promote products derived
+ * 	  from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PRU_TYPES_H_
+#define _PRU_TYPES_H_
+
+/* Custom Resource info: Must match drivers/remoteproc/pru_rproc.h */
+#define TYPE_PRU_INTS		1
+
+/**
+ * struct ch_map - sysevts-to-channel mapping
+ *
+ * @evt: the number of the sysevt
+ * @ch: channel number assigned to a given @sysevt
+ *
+ * PRU system events are mapped to channels, and these channels are mapped to
+ * hosts. Events can be mapped to channels in a one-to-one or many-to-one ratio
+ * (multiple events per channel), and channels can be mapped to hosts in a
+ * one-to-one or many-to-one ratio (multiple events per channel).
+ *
+ * @evt is the number of the sysevt, and @ch is the number of the channel to be
+ * mapped.
+ */
+
+struct ch_map {
+	uint8_t evt;
+	uint8_t ch;
+};
+
+/**
+ * struct fw_rsc_custom_ints - custom resource to define PRU interrupts
+ * @version: revision number of the custom ints type
+ * @channel_host: assignment of PRU channels to hosts
+ * @num_evts: device address of INTC
+ * @event_channel: mapping of sysevts to channels
+ *
+ * PRU system events are mapped to channels, and these channels are mapped to
+ * hosts. Events can be mapped to channels in a one-to-one or many-to-one ratio
+ * (multiple events per channel), and channels can be mapped to hosts in a
+ * one-to-one or many-to-one ratio (multiple events per channel).
+ *
+ * @da is the device address of the interrupt controller, @channel_map is
+ * used to specify to which channel, if any, an event is mapped, and @host_map
+ * specifies to which host, if any, a channel is mapped.
+ */
+struct fw_rsc_custom_ints {
+	uint16_t version;
+	uint8_t channel_host[10];
+	uint32_t num_evts;
+	struct ch_map *event_channel;
+};
+
+#endif /* _PRU_TYPES_H_ */

--- a/include/resource_table_empty.h
+++ b/include/resource_table_empty.h
@@ -51,7 +51,7 @@
 #define _RSC_TABLE_PRU_H_
 
 #include <stddef.h>
-#include <rsc_types.h>
+#include "rsc_types.h"
 
 struct my_resource_table {
 	struct resource_table base;


### PR DESCRIPTION
Since all of the TI Linux SDK code which applies to PRU firmware is
licensed by TI under the BSD 3 clause license (see header files in
include/ directory for license) and since the BSD 3 clause license is
compatible with the GPLv2, simply copy the needed header files from TI's
Linux SDK into this code repository so that any user wishing to compile
this firmware does not need to have previously installed the TI Linux
SDK (as it is quite onerous to do so).

Signed-off-by: Andrew Bradford andrew@bradfordembedded.com
