### PR TITLE
driver: Create Kbuild and README, fix easy compile errors

### DIFF
--- a/Driver/Kbuild
+++ b/Driver/Kbuild
@@ -1,0 +1,1 @@
+obj-m += pru-spi.o

--- a/Driver/README
+++ b/Driver/README
@@ -1,0 +1,8 @@
+To compile this kernel module, first you must have the kernel sources you want
+to build against setup correctly.  Please see the Linux kernel documentation
+within the Linux source directory Documentation/kbuild/ for more information.
+
+Then, to build this kernel module, simply execute (but replace the path with
+your path to your correctly setup Linux kernel source code):
+
+make -C <path/to/linux/kernel/sources> M=$PWD


### PR DESCRIPTION
Rename the driver .c file.
Create a simple Kbuild file for the module build.
Create a README to explain how to build the module.
Fix the easier compile errors, still there remain many compile errors.

Signed-off-by: Andrew Bradford andrew@bradfordembedded.com
