### PR TITLE
Small fixes for Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 *.s
 pru0_spi
 gen/*
+*.dwo
+*.ko
+*.mod.*
+Module.symvers
+.tmp_versions/
+modules.order

--- a/Driver/.tmp_versions/pru-spi.mod
+++ b/Driver/.tmp_versions/pru-spi.mod
@@ -1,2 +1,0 @@
-/home/vc/Desktop/beagle-gsoc/Firmware/Driver/pru-spi.ko
-/home/vc/Desktop/beagle-gsoc/Firmware/Driver/pru-spi.o

--- a/Driver/modules.order
+++ b/Driver/modules.order
@@ -1,1 +1,0 @@
-kernel//home/vc/Desktop/beagle-gsoc/Firmware/Driver/pru-spi.ko

--- a/Driver/pru-spi.c
+++ b/Driver/pru-spi.c
@@ -44,7 +44,7 @@ static ssize_t spi_write(struct file *filp, const char __user *buf, size_t count
 	uint8_t mosi_transfer=*mosi;
 	iowrite8(mosi_transfer,Data_pointer);
 }
-static ssize_t spi_read(struct file *filp, const char __user *buf, size_t count,loff_t *f_pos)
+static ssize_t spi_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 {
 	uint8_t miso_transfer=ioread8(Data_pointer);
 	*miso=miso_transfer;


### PR DESCRIPTION
- Fix GCC6 compile error.
- Get build artifacts out of git and keep them out.
